### PR TITLE
Security/harden file operations and commands

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   TargetRubyVersion: 2.6
-  new_cops: enable
+  NewCops: enable
   Exclude:
     - 'spec/**/*'
 
@@ -23,6 +23,9 @@ Metrics/MethodLength:
 
 Metrics/AbcSize:
   Max: 30
+
+Metrics/ModuleLength:
+  Max: 150
 
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
This pull request introduces significant improvements to the security and validation logic in the `Rbgithook` library, along with updates to the `.rubocop.yml` configuration. The changes focus on enhancing file name validation, ensuring secure file paths, and adding comprehensive test coverage for these updates.

### Security and Validation Enhancements:
* Refactored `validate_file_name` to delegate checks to new methods: `check_path_traversal_patterns`, `check_hidden_file_patterns`, `check_control_characters`, and `check_allowed_characters`. These methods provide granular validation for path traversal, hidden files, control characters, and allowed characters.
* Added `ensure_secure_directory` to create the `.rbgithook` directory with secure permissions if it does not exist.
* Introduced `validate_secure_file_path` to ensure file paths remain within the designated directory, prevent symlink traversal, and detect path manipulation.

### Test Coverage Additions:
* Expanded test cases in `spec/rbgithook_spec.rb` to cover all new validation methods, including checks for path traversal patterns, URL-encoded traversal, null byte injection, hidden files, control characters, and invalid characters.
* Added tests for `ensure_secure_directory` to verify directory creation and permission settings.
* Added tests for `validate_secure_file_path` to ensure it correctly handles safe paths, rejects dangerous paths, and prevents symlink traversal.

### Configuration Updates:
* Fixed capitalization of `NewCops` in `.rubocop.yml` to align with RuboCop's expected format.
* Added a new `Metrics/ModuleLength` rule with a maximum length of 150 to `.rubocop.yml`.